### PR TITLE
Change average norm parameter to 1 in modelBuild.sh.

### DIFF
--- a/modelbuild.sh
+++ b/modelbuild.sh
@@ -697,7 +697,7 @@ fi
 if [[ ${_arg_average_norm} == "off" ]]; then
   unset _arg_average_norm
 else
-  _arg_average_norm=2
+  _arg_average_norm=1
 fi
 
 # Averaging function


### PR DESCRIPTION
**BUG:**

When running the script with normalization enabled, running AverageImages from the script results in the following error

`ERROR:  Normalize option must be 0 or 1, 2given`

In the script, the following snippet sets this parameter

```
if [[ ${_arg_average_norm} == "off" ]]; then
  unset _arg_average_norm
else
  _arg_average_norm=2
fi
```
**FIX**
Changing this to 1 fixes the error, and allows the script to continue running. 


