### PR TITLE
Strip empty fields from comma-separated input rows in twolevel scripts

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -127,6 +127,17 @@ function extension_strip() {
   sed -r 's/(.nii$|.nii.gz|.nrrd|.mnc|.mnc.gz)$//'
 }
 
+function filter_empty() {
+  # Remove empty elements from a named array (in place).
+  # Usage: filter_empty <array_name>
+  local -n __arr=$1
+  local __filtered=() __elem
+  for __elem in "${__arr[@]}"; do
+    [[ -n ${__elem} ]] && __filtered+=("${__elem}")
+  done
+  __arr=("${__filtered[@]}")
+}
+
 function preflight_check() {
   # Preflight check for required programs
   for program in AverageImages ImageSetStatistics ResampleImage qbatch ImageMath \

--- a/twolevel_commonspace_resample.sh
+++ b/twolevel_commonspace_resample.sh
@@ -199,9 +199,11 @@ while read -r subject_scans; do
   mkdir -p ${_arg_output_dir}/secondlevel/commonspace-resampled/subject_${i}
   IFS=',' read -r -a scans <<<${subject_scans}
   filter_empty scans
+  [[ ${#scans[@]} -eq 0 ]] && failure "Subject ${i}: input row contains no valid scan paths after filtering empty fields"
   if [[ -n ${_arg_prepend_transforms} ]]; then
     IFS=',' read -r -a transforms <<< $(sed "${i}q;d" ${_arg_prepend_transforms})
     filter_empty transforms
+    [[ ${#transforms[@]} -eq 0 ]] && failure "Subject ${i}: --prepend-transforms row contains no valid transforms after filtering empty fields"
     prepend_transforms="--prepend-transforms ${_arg_output_dir}/secondlevel/commonspace-resampled/subject_${i}/prepend_transforms.txt"
     printf "%s\n" "${transforms[@]}" > ${_arg_output_dir}/secondlevel/commonspace-resampled/subject_${i}/prepend_transforms.txt
   else
@@ -210,6 +212,7 @@ while read -r subject_scans; do
   fi
   IFS=',' read -r -a resample_inputs <<< $(sed "${i}q;d" ${_arg_resample_inputs})
   filter_empty resample_inputs
+  [[ ${#resample_inputs[@]} -eq 0 ]] && failure "Subject ${i}: --resample-inputs row contains no valid paths after filtering empty fields"
 
   printf "%s\n" "${resample_inputs[@]}" > ${_arg_output_dir}/secondlevel/commonspace-resampled/subject_${i}/resample_inputs.txt
 

--- a/twolevel_commonspace_resample.sh
+++ b/twolevel_commonspace_resample.sh
@@ -192,6 +192,16 @@ echo ${__invocation} >${_arg_output_dir}/secondlevel/jobs/${__datetime}/invocati
 
 mkdir -p ${_arg_output_dir}/secondlevel/commonspace-resampled
 
+# Validate row counts of paired CSV files match the primary inputs file so
+# trailing subjects don't silently end up with empty lookups via sed.
+inputs_lines=$(wc -l < ${_arg_inputs})
+resample_inputs_lines=$(wc -l < ${_arg_resample_inputs})
+[[ ${resample_inputs_lines} -ne ${inputs_lines} ]] && failure "--resample-inputs ${_arg_resample_inputs} has ${resample_inputs_lines} rows, expected ${inputs_lines} to match --inputs"
+if [[ -n ${_arg_prepend_transforms} ]]; then
+  prepend_transforms_lines=$(wc -l < ${_arg_prepend_transforms})
+  [[ ${prepend_transforms_lines} -ne ${inputs_lines} ]] && failure "--prepend-transforms ${_arg_prepend_transforms} has ${prepend_transforms_lines} rows, expected ${inputs_lines} to match --inputs"
+fi
+
 info "Processing Two-Level Common Resampling"
 i=1
 while read -r subject_scans; do

--- a/twolevel_commonspace_resample.sh
+++ b/twolevel_commonspace_resample.sh
@@ -198,8 +198,10 @@ while read -r subject_scans; do
 
   mkdir -p ${_arg_output_dir}/secondlevel/commonspace-resampled/subject_${i}
   IFS=',' read -r -a scans <<<${subject_scans}
+  filter_empty scans
   if [[ -n ${_arg_prepend_transforms} ]]; then
     IFS=',' read -r -a transforms <<< $(sed "${i}q;d" ${_arg_prepend_transforms})
+    filter_empty transforms
     prepend_transforms="--prepend-transforms ${_arg_output_dir}/secondlevel/commonspace-resampled/subject_${i}/prepend_transforms.txt"
     printf "%s\n" "${transforms[@]}" > ${_arg_output_dir}/secondlevel/commonspace-resampled/subject_${i}/prepend_transforms.txt
   else
@@ -207,6 +209,7 @@ while read -r subject_scans; do
     prepend_transforms=""
   fi
   IFS=',' read -r -a resample_inputs <<< $(sed "${i}q;d" ${_arg_resample_inputs})
+  filter_empty resample_inputs
 
   printf "%s\n" "${resample_inputs[@]}" > ${_arg_output_dir}/secondlevel/commonspace-resampled/subject_${i}/resample_inputs.txt
 

--- a/twolevel_dbm.sh
+++ b/twolevel_dbm.sh
@@ -389,6 +389,71 @@ while read -r subject_scans; do
 
   else
     info "Subject ${i} has only a single file, "${scans[@]}", and does not have a subject wise average, it will only have second-level cross sectional DBM"
+
+    for scan in "${scans[@]}"; do
+      info "Generating Overall Jacobian Determinants"
+      if [[ ${_arg_target_space} == "unbiased" ]]; then
+        if [[ ! -s ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/full/$(basename ${scan} | extension_strip).nii.gz ]]; then
+          echo "ln -sfr ${_arg_output_dir}/secondlevel/dbm/jacobian/full/subject_${i}.nii.gz \
+            ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/full/$(basename ${scan} | extension_strip).nii.gz"
+        fi
+        if [[ ! -s ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/relative/$(basename ${scan} | extension_strip).nii.gz ]]; then
+          echo "ln -sfr ${_arg_output_dir}/secondlevel/dbm/jacobian/relative/subject_${i}.nii.gz \
+            ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/relative/$(basename ${scan} | extension_strip).nii.gz"
+        fi
+      else
+        mkdir -p ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/{relative,full}/final-target/smooth
+        if [[ ! -s ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/full/final-target/$(basename ${scan} | extension_strip).nii.gz ]]; then
+          echo "ln -sfr ${_arg_output_dir}/secondlevel/dbm/jacobian/final-target/full/subject_${i}.nii.gz \
+            ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/full/final-target/$(basename ${scan} | extension_strip).nii.gz"
+        fi
+        if [[ ! -s ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/relative/final-target/$(basename ${scan} | extension_strip).nii.gz ]]; then
+          echo "ln -sfr ${_arg_output_dir}/secondlevel/dbm/jacobian/final-target/relative/subject_${i}.nii.gz \
+            ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/relative/final-target/$(basename ${scan} | extension_strip).nii.gz"
+        fi
+      fi
+    done >>${_arg_output_dir}/secondlevel/dbm/jobs/${__datetime}/overall_jacobian
+
+    for scan in "${scans[@]}"; do
+      info "Smoothing Jacobian Determinants"
+      for fwhm in "${_arg_jacobian_smooth_list[@]}"; do
+        sigma_num=$(calc "$(echo ${fwhm} | grep -o -E '^[0-9]+')/(2*sqrt(2*log(2)))")
+        if [[ ${fwhm} =~ [0-9]+mm$ ]]; then
+          fwhm_type=1
+        elif [[ ${fwhm} =~ [0-9]+vox$ ]]; then
+          fwhm_type=0
+        else
+          failure "Parse error for FWHM entry \"${fwhm}\", must end with vox or mm"
+        fi
+        if [[ ${_arg_target_space} == "unbiased" ]]; then
+          if [[ ! -s ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/full/smooth/$(basename ${scan} | extension_strip)_fwhm_${fwhm}.nii.gz ]]; then
+            echo "SmoothImage 3 \
+              ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/full/$(basename ${scan} | extension_strip).nii.gz \
+              ${sigma_num} \
+              ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/full/smooth/$(basename ${scan} | extension_strip)_fwhm_${fwhm}.nii.gz ${fwhm_type} 0"
+          fi
+          if [[ ! -s ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/relative/smooth/$(basename ${scan} | extension_strip)_fwhm_${fwhm}.nii.gz ]]; then
+            echo "SmoothImage 3 \
+              ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/relative/$(basename ${scan} | extension_strip).nii.gz \
+              ${sigma_num} \
+              ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/relative/smooth/$(basename ${scan} | extension_strip)_fwhm_${fwhm}.nii.gz ${fwhm_type} 0"
+          fi
+        else
+          if [[ ! -s ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/full/final-target/smooth/$(basename ${scan} | extension_strip)_fwhm_${fwhm}.nii.gz ]]; then
+            echo "SmoothImage 3 \
+              ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/full/final-target/$(basename ${scan} | extension_strip).nii.gz \
+              ${sigma_num} \
+              ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/full/final-target/smooth/$(basename ${scan} | extension_strip)_fwhm_${fwhm}.nii.gz ${fwhm_type} 0"
+          fi
+          if [[ ! -s ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/relative/final-target/smooth/$(basename ${scan} | extension_strip)_fwhm_${fwhm}.nii.gz ]]; then
+            echo "SmoothImage 3 \
+              ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/relative/final-target/$(basename ${scan} | extension_strip).nii.gz \
+              ${sigma_num} \
+              ${_arg_output_dir}/secondlevel/overall-dbm/jacobian/relative/final-target/smooth/$(basename ${scan} | extension_strip)_fwhm_${fwhm}.nii.gz ${fwhm_type} 0"
+          fi
+        fi
+      done
+    done >>${_arg_output_dir}/secondlevel/dbm/jobs/${__datetime}/smooth_jacobian
   fi
 
   ((++i))

--- a/twolevel_dbm.sh
+++ b/twolevel_dbm.sh
@@ -234,6 +234,7 @@ while read -r subject_scans; do
 
   IFS=',' read -r -a scans <<<${subject_scans}
   filter_empty scans
+  [[ ${#scans[@]} -eq 0 ]] && failure "Subject ${i}: input row contains no valid scan paths after filtering empty fields"
   if [[ $(wc -l < ${_arg_output_dir}/firstlevel/subject_${i}/input_files.txt) -gt 1 ]]; then
     debug "${__dir}/dbm.sh ${_arg_debug:+--debug} ${_arg_leftovers[@]+"${_arg_leftovers[@]}"} --jobname-prefix "dbm_twolevel_${__datetime}_subject_${i}_" --jacobian-smooth "${_arg_jacobian_smooth}" --output-dir ${_arg_output_dir}/firstlevel/subject_${i} ${_arg_output_dir}/firstlevel/subject_${i}/input_files.txt"
     if [[ ${_arg_dry_run} == "off" ]]; then

--- a/twolevel_dbm.sh
+++ b/twolevel_dbm.sh
@@ -233,6 +233,7 @@ i=1
 while read -r subject_scans; do
 
   IFS=',' read -r -a scans <<<${subject_scans}
+  filter_empty scans
   if [[ $(wc -l < ${_arg_output_dir}/firstlevel/subject_${i}/input_files.txt) -gt 1 ]]; then
     debug "${__dir}/dbm.sh ${_arg_debug:+--debug} ${_arg_leftovers[@]+"${_arg_leftovers[@]}"} --jobname-prefix "dbm_twolevel_${__datetime}_subject_${i}_" --jacobian-smooth "${_arg_jacobian_smooth}" --output-dir ${_arg_output_dir}/firstlevel/subject_${i} ${_arg_output_dir}/firstlevel/subject_${i}/input_files.txt"
     if [[ ${_arg_dry_run} == "off" ]]; then

--- a/twolevel_modelbuild.sh
+++ b/twolevel_modelbuild.sh
@@ -252,6 +252,7 @@ info "Launching modelbuilds for each input row"
 i=1
 while read -r subject_scans; do
   IFS=',' read -r -a scans <<<${subject_scans}
+  filter_empty scans
   mkdir -p ${_arg_output_dir}/firstlevel/subject_${i}
   ln -sfr ${_arg_output_dir}/firstlevel/subject_${i}/final/average/template_sharpen_shapeupdate.nii.gz ${_arg_output_dir}/secondlevel/inputs/subject_${i}.nii.gz
   printf "%s\n" ${_arg_output_dir}/secondlevel/inputs/subject_${i}.nii.gz >> ${_arg_output_dir}/secondlevel/input_files.txt
@@ -259,6 +260,7 @@ while read -r subject_scans; do
 
   if [[ -n ${_arg_masks} ]]; then
     IFS=',' read -r -a masks <<<$(sed "${i}q;d" ${_arg_masks})
+    filter_empty masks
     ln -sfr ${_arg_output_dir}/firstlevel/subject_${i}/final/average/mask_shapeupdate.nii.gz ${_arg_output_dir}/secondlevel/masks/subject_${i}.nii.gz
     printf "%s\n" ${_arg_output_dir}/secondlevel/masks/subject_${i}.nii.gz >> ${_arg_output_dir}/secondlevel/mask_files.txt
     printf "%s\n" "${masks[@]}" > ${_arg_output_dir}/firstlevel/subject_${i}/mask_files.txt

--- a/twolevel_modelbuild.sh
+++ b/twolevel_modelbuild.sh
@@ -253,6 +253,7 @@ i=1
 while read -r subject_scans; do
   IFS=',' read -r -a scans <<<${subject_scans}
   filter_empty scans
+  [[ ${#scans[@]} -eq 0 ]] && failure "Subject ${i}: input row contains no valid scan paths after filtering empty fields"
   mkdir -p ${_arg_output_dir}/firstlevel/subject_${i}
   ln -sfr ${_arg_output_dir}/firstlevel/subject_${i}/final/average/template_sharpen_shapeupdate.nii.gz ${_arg_output_dir}/secondlevel/inputs/subject_${i}.nii.gz
   printf "%s\n" ${_arg_output_dir}/secondlevel/inputs/subject_${i}.nii.gz >> ${_arg_output_dir}/secondlevel/input_files.txt
@@ -261,6 +262,8 @@ while read -r subject_scans; do
   if [[ -n ${_arg_masks} ]]; then
     IFS=',' read -r -a masks <<<$(sed "${i}q;d" ${_arg_masks})
     filter_empty masks
+    [[ ${#masks[@]} -eq 0 ]] && failure "Subject ${i}: mask input row contains no valid mask paths after filtering empty fields"
+    [[ ${#masks[@]} -ne ${#scans[@]} ]] && failure "Subject ${i}: number of masks (${#masks[@]}) does not match number of scans (${#scans[@]})"
     ln -sfr ${_arg_output_dir}/firstlevel/subject_${i}/final/average/mask_shapeupdate.nii.gz ${_arg_output_dir}/secondlevel/masks/subject_${i}.nii.gz
     printf "%s\n" ${_arg_output_dir}/secondlevel/masks/subject_${i}.nii.gz >> ${_arg_output_dir}/secondlevel/mask_files.txt
     printf "%s\n" "${masks[@]}" > ${_arg_output_dir}/firstlevel/subject_${i}/mask_files.txt

--- a/twolevel_subjectspace_resample.sh
+++ b/twolevel_subjectspace_resample.sh
@@ -242,6 +242,18 @@ elif [[ ${_arg_resample_input_space} == "final-target" ]]; then
   fi
 fi
 
+# Validate row counts of paired CSV files match the primary inputs file so
+# trailing subjects don't silently end up with empty lookups via sed.
+inputs_lines=$(wc -l < ${_arg_inputs})
+if [[ -n ${_arg_append_transforms} ]]; then
+  append_transforms_lines=$(wc -l < ${_arg_append_transforms})
+  [[ ${append_transforms_lines} -ne ${inputs_lines} ]] && failure "--append-transforms ${_arg_append_transforms} has ${append_transforms_lines} rows, expected ${inputs_lines} to match --inputs"
+fi
+if [[ -n ${_arg_target_space} ]]; then
+  target_space_lines=$(wc -l < ${_arg_target_space})
+  [[ ${target_space_lines} -ne ${inputs_lines} ]] && failure "--target-space ${_arg_target_space} has ${target_space_lines} rows, expected ${inputs_lines} to match --inputs"
+fi
+
 info "Processing Two-Level Resampling"
 i=1
 while read -r subject_scans; do

--- a/twolevel_subjectspace_resample.sh
+++ b/twolevel_subjectspace_resample.sh
@@ -248,10 +248,12 @@ while read -r subject_scans; do
   mkdir -p ${_arg_output_dir}/subjectspace-resampled/subject_${i}
   IFS=',' read -r -a scans <<<${subject_scans}
   filter_empty scans
+  [[ ${#scans[@]} -eq 0 ]] && failure "Subject ${i}: input row contains no valid scan paths after filtering empty fields"
   # Save append-transforms for individual subjects
   if [[ -n ${_arg_append_transforms} ]]; then
     IFS=',' read -r -a transforms <<< $(sed "${i}q;d" ${_arg_append_transforms})
     filter_empty transforms
+    [[ ${#transforms[@]} -eq 0 ]] && failure "Subject ${i}: --append-transforms row contains no valid transforms after filtering empty fields"
     append_transforms="--append-transforms ${_arg_output_dir}/subjectspace-resampled/subject_${i}/append_transforms.txt"
     printf "%s\n" "${transforms[@]}" > ${_arg_output_dir}/subjectspace-resampled/subject_${i}/append_transforms.txt
   else
@@ -263,6 +265,7 @@ while read -r subject_scans; do
   if [[ -n ${_arg_target_space} ]]; then
     IFS=',' read -r -a target_space <<< $(sed "${i}q;d" ${_arg_target_space})
     filter_empty target_space
+    [[ ${#target_space[@]} -eq 0 ]] && failure "Subject ${i}: --target-space row contains no valid paths after filtering empty fields"
     target_space_cmd="--target-space ${temp_target_space_file}"
     printf "%s\n" "${target_space[@]}" > ${temp_target_space_file}
   else

--- a/twolevel_subjectspace_resample.sh
+++ b/twolevel_subjectspace_resample.sh
@@ -247,9 +247,11 @@ i=1
 while read -r subject_scans; do
   mkdir -p ${_arg_output_dir}/subjectspace-resampled/subject_${i}
   IFS=',' read -r -a scans <<<${subject_scans}
+  filter_empty scans
   # Save append-transforms for individual subjects
   if [[ -n ${_arg_append_transforms} ]]; then
     IFS=',' read -r -a transforms <<< $(sed "${i}q;d" ${_arg_append_transforms})
+    filter_empty transforms
     append_transforms="--append-transforms ${_arg_output_dir}/subjectspace-resampled/subject_${i}/append_transforms.txt"
     printf "%s\n" "${transforms[@]}" > ${_arg_output_dir}/subjectspace-resampled/subject_${i}/append_transforms.txt
   else
@@ -260,6 +262,7 @@ while read -r subject_scans; do
   temp_target_space_file="${_arg_output_dir}/subjectspace-resampled/subject_${i}/target_space.txt"
   if [[ -n ${_arg_target_space} ]]; then
     IFS=',' read -r -a target_space <<< $(sed "${i}q;d" ${_arg_target_space})
+    filter_empty target_space
     target_space_cmd="--target-space ${temp_target_space_file}"
     printf "%s\n" "${target_space[@]}" > ${temp_target_space_file}
   else


### PR DESCRIPTION
Users naturally produce CSV input rows of uneven width (zero-padded with trailing/leading/embedded commas) when subjects have different numbers of timepoints. IFS=',' splitting preserved those as empty array elements, which were then written as blank lines into per-subject input_files.txt and tripped basename in modelbuild.sh. Add a filter_empty helper and apply it after every row split across the four twolevel wrappers.

Fixes #135.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Overall second-level Jacobian outputs are now produced and scheduled for smoothing, ensuring consolidated results are available for downstream analysis.

* **Bug Fixes**
  * Improved input sanitization for comma-separated lists to remove empty entries, avoiding invalid paths.
  * Added guards to halt processing when no valid scan or mask paths remain, preventing silent failures and downstream errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->